### PR TITLE
Rename turntable step and fast meshing.

### DIFF
--- a/MF/V3/Descriptors/Settings/Turntable.proto
+++ b/MF/V3/Descriptors/Settings/Turntable.proto
@@ -5,8 +5,8 @@ package MF.V3.Descriptors.Settings;
 // Turntable settings descriptor.
 message Turntable
 {
-    // The number of turntable steps.
-    message Steps
+    // The number of turntable scans.
+    message Scans
     {
         int32 value = 1;
         int32 default = 2;
@@ -30,8 +30,8 @@ message Turntable
         bool default = 2;
     }
 
-    // The number of turntable steps.
-    Steps steps = 1;
+    // The number of turntable scans.
+    Scans scans = 1;
 
     // Turntable angle sweep in degrees.
     Sweep sweep = 2;

--- a/MF/V3/Settings/Merge.proto
+++ b/MF/V3/Settings/Merge.proto
@@ -14,21 +14,21 @@ message Merge
         // Remesh method.
         enum Method
         {
-            // Fast remesh as triangles.
-            FastTriangles = 0;
+            // Flow remesh as triangles.
+            FlowTriangles = 0;
             
-            // Fast remesh as quads.
-            FastQuads = 1;
+            // Flow remesh as quads.
+            FlowQuads = 1;
             
-            // Fast remesh as quad-dominant mesh.
-            FastQuadDominant = 2;
+            // Flow remesh as quad-dominant mesh.
+            FlowQuadDominant = 2;
             
             // Poisson remesh as triangles.
             PoissonTriangles = 3;
         }
         
-        // Fast remesh settings
-        message Fast
+        // Flow remesh settings
+        message Flow
         {            
             // Output resolution scale.  Smaller means more faces.
             optional float scale = 3;
@@ -79,8 +79,8 @@ message Merge
         // Remesh quality.
         optional Quality quality = 2;
         
-        // Fast remesh options (Ignored if method is 'Poison').
-        optional Fast fast = 3;
+        // Flow remesh options (Ignored if method is 'Poison').
+        optional Flow flow = 3;
         
         // Poisson remesh options (Ignored if method is not 'Poisson').
         optional Poisson poisson = 4;

--- a/MF/V3/Settings/Turntable.proto
+++ b/MF/V3/Settings/Turntable.proto
@@ -8,8 +8,8 @@ message Turntable
     // Use the turntable.
     optional bool use = 1;
 
-    // The number of turntable steps.
-    int32 steps = 2;
+    // The number of turntable scans.
+    int32 scans = 2;
 
     // Turntable angle sweep in degrees.
     int32 sweep = 3;

--- a/MF/V3/Tasks/ListSettings.proto
+++ b/MF/V3/Tasks/ListSettings.proto
@@ -35,7 +35,7 @@ package MF.V3;
  *                 "on":{"default":false,"value":true}
  *             },
  *             "turntable":{
- *                 "steps":{"default":8,"max":24,"min":1,"value":3},
+ *                 "scans":{"default":8,"max":24,"min":1,"value":3},
  *                 "sweep":{"default":360,"max":360,"min":5,"value":90},
  *                 "use":{"default":true,"value":true}
  *              },

--- a/MF/V3/Tasks/Merge.proto
+++ b/MF/V3/Tasks/Merge.proto
@@ -19,7 +19,7 @@ package MF.V3;
  *         "Input":{
  *             "selection":{"mode":"visible"},
  *             "remesh":{
- *                 "method": "FastTriangles",
+ *                 "method": "FlowTriangles",
  *                 "quality": "Medium"
  *             },
  *             "simplify":{"triangleCount": 20000 }
@@ -36,7 +36,7 @@ package MF.V3;
  *         "Input":{
  *             "selection":{"mode":"visible"},
  *             "remesh":{
- *                 "method": "FastTriangles",
+ *                 "method": "FlowTriangles",
  *                 "quality": "Medium"
  *             },
  *             "simplify":{"triangleCount": 20000 }

--- a/MF/V3/Tasks/PopSettings.proto
+++ b/MF/V3/Tasks/PopSettings.proto
@@ -37,7 +37,7 @@ package MF.V3;
  *                 "on":{"default":false,"value":true}
  *             },
  *             "turntable":{
- *                 "steps":{"default":8,"max":24,"min":1,"value":3},
+ *                 "scans":{"default":8,"max":24,"min":1,"value":3},
  *                 "sweep":{"default":360,"max":360,"min":5,"value":90},
  *                 "use":{"default":true,"value":true}
  *              },

--- a/MF/V3/Tasks/PushSettings.proto
+++ b/MF/V3/Tasks/PushSettings.proto
@@ -35,7 +35,7 @@ package MF.V3;
  *                 "on":{"default":false,"value":true}
  *             },
  *             "turntable":{
- *                 "steps":{"default":8,"max":24,"min":1,"value":3},
+ *                 "scans":{"default":8,"max":24,"min":1,"value":3},
  *                 "sweep":{"default":360,"max":360,"min":5,"value":90},
  *                 "use":{"default":true,"value":true}
  *              },

--- a/MF/V3/Tasks/UpdateSettings.proto
+++ b/MF/V3/Tasks/UpdateSettings.proto
@@ -50,7 +50,7 @@ package MF.V3;
  *                 "on":{"default":false,"value":true}
  *             },
  *             "turntable":{
- *                 "steps":{"default":8,"max":24,"min":1,"value":3},
+ *                 "scans":{"default":8,"max":24,"min":1,"value":3},
  *                 "sweep":{"default":360,"max":360,"min":5,"value":90},
  *                 "use":{"default":true,"value":true}
  *              },


### PR DESCRIPTION
1. turntable `steps` renamed to `scans`.
2. `Fast` meshing renamed to `Flow` meshing.