### PR TITLE
Updating Package definitions for Tasks

### DIFF
--- a/MF/V3/Tasks/AddMergeToProject.proto
+++ b/MF/V3/Tasks/AddMergeToProject.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Add a merged scan to the current project.

--- a/MF/V3/Tasks/Align.proto
+++ b/MF/V3/Tasks/Align.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Align.proto";
 import "MF/V3/Descriptors/Transform.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Align two scan groups.

--- a/MF/V3/Tasks/AutoFocus.proto
+++ b/MF/V3/Tasks/AutoFocus.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/AutoFocus.proto";
 import "MF/V3/Descriptors/Settings/Camera.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Auto focus one or both cameras.

--- a/MF/V3/Tasks/BoundingBox.proto
+++ b/MF/V3/Tasks/BoundingBox.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/BoundingBox.proto";
 import "MF/V3/Descriptors/BoundingBox.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Get the bounding box of a set of scan groups.

--- a/MF/V3/Tasks/CalibrateCameras.proto
+++ b/MF/V3/Tasks/CalibrateCameras.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Calibrate the cameras.

--- a/MF/V3/Tasks/CalibrateTurntable.proto
+++ b/MF/V3/Tasks/CalibrateTurntable.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Calibration.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Calibrate the turntable.

--- a/MF/V3/Tasks/CalibrationCaptureTargets.proto
+++ b/MF/V3/Tasks/CalibrationCaptureTargets.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Calibration.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Get the camera calibration targets.

--- a/MF/V3/Tasks/CameraCalibration.proto
+++ b/MF/V3/Tasks/CameraCalibration.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Calibration.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Get the camera calibration descriptor.

--- a/MF/V3/Tasks/CloseProject.proto
+++ b/MF/V3/Tasks/CloseProject.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Close the current open project.

--- a/MF/V3/Tasks/ConnectWifi.proto
+++ b/MF/V3/Tasks/ConnectWifi.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Settings/Wifi.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Connect to a wifi network.

--- a/MF/V3/Tasks/DepthMap.proto
+++ b/MF/V3/Tasks/DepthMap.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Scan.proto";
 import "MF/V3/Descriptors/Image.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Capture a new scan.

--- a/MF/V3/Tasks/DetectCalibrationCard.proto
+++ b/MF/V3/Tasks/DetectCalibrationCard.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Detect the calibration card on one or both cameras.

--- a/MF/V3/Tasks/DownloadProject.proto
+++ b/MF/V3/Tasks/DownloadProject.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Download a project from the scanner.

--- a/MF/V3/Tasks/Export.proto
+++ b/MF/V3/Tasks/Export.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Settings/Export.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Export a group of scans.

--- a/MF/V3/Tasks/ExportLogs.proto
+++ b/MF/V3/Tasks/ExportLogs.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Export scanner logs.

--- a/MF/V3/Tasks/ExportMerge.proto
+++ b/MF/V3/Tasks/ExportMerge.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Settings/Export.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Export a merged scan.

--- a/MF/V3/Tasks/FlattenGroup.proto
+++ b/MF/V3/Tasks/FlattenGroup.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Flatten a scan group such that it only consists of single scans.

--- a/MF/V3/Tasks/ForgetWifi.proto
+++ b/MF/V3/Tasks/ForgetWifi.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Forget all wifi connections.

--- a/MF/V3/Tasks/HasCameras.proto
+++ b/MF/V3/Tasks/HasCameras.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Check if the scanner has working cameras.

--- a/MF/V3/Tasks/HasProjector.proto
+++ b/MF/V3/Tasks/HasProjector.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Check if the scanner has a working projector.

--- a/MF/V3/Tasks/HasTurntable.proto
+++ b/MF/V3/Tasks/HasTurntable.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Check if the scanner is connected to a working turntable.

--- a/MF/V3/Tasks/ListExportFormats.proto
+++ b/MF/V3/Tasks/ListExportFormats.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Export.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * List all export formats and the geometry elements they support.

--- a/MF/V3/Tasks/ListGroups.proto
+++ b/MF/V3/Tasks/ListGroups.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * List the scan groups in the current open project.

--- a/MF/V3/Tasks/ListNetworkInterfaces.proto
+++ b/MF/V3/Tasks/ListNetworkInterfaces.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Network.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * List network interfaces.

--- a/MF/V3/Tasks/ListProjects.proto
+++ b/MF/V3/Tasks/ListProjects.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * List all projects.

--- a/MF/V3/Tasks/ListScans.proto
+++ b/MF/V3/Tasks/ListScans.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * List the scans in the current open project.

--- a/MF/V3/Tasks/ListSettings.proto
+++ b/MF/V3/Tasks/ListSettings.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Settings/Scanner.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Get scanner settings.

--- a/MF/V3/Tasks/ListWifi.proto
+++ b/MF/V3/Tasks/ListWifi.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Wifi.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * List available wifi networks.

--- a/MF/V3/Tasks/Merge.proto
+++ b/MF/V3/Tasks/Merge.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Merge.proto";
 import "MF/V3/Descriptors/Merge.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Merge two or more scan groups.

--- a/MF/V3/Tasks/MergeData.proto
+++ b/MF/V3/Tasks/MergeData.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/ScanData.proto";
 import "MF/V3/Descriptors/ScanData.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Download the raw scan data for the current merge process.

--- a/MF/V3/Tasks/MoveGroup.proto
+++ b/MF/V3/Tasks/MoveGroup.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Move a scan group.

--- a/MF/V3/Tasks/NewGroup.proto
+++ b/MF/V3/Tasks/NewGroup.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/NewGroup.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Create a new scan group.

--- a/MF/V3/Tasks/NewProject.proto
+++ b/MF/V3/Tasks/NewProject.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Project.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Create a new project.

--- a/MF/V3/Tasks/NewScan.proto
+++ b/MF/V3/Tasks/NewScan.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Scan.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Capture a new scan.

--- a/MF/V3/Tasks/OpenProject.proto
+++ b/MF/V3/Tasks/OpenProject.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Create a new project.

--- a/MF/V3/Tasks/PopSettings.proto
+++ b/MF/V3/Tasks/PopSettings.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Settings/Scanner.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Pop and restore scanner settings from the stack and optionally apply the popped settings.

--- a/MF/V3/Tasks/PushSettings.proto
+++ b/MF/V3/Tasks/PushSettings.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Settings/Scanner.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Push the current scanner settings to a stack so they can be restored with PopSettings.

--- a/MF/V3/Tasks/Reboot.proto
+++ b/MF/V3/Tasks/Reboot.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Reboot the scanner.

--- a/MF/V3/Tasks/RemoveGroups.proto
+++ b/MF/V3/Tasks/RemoveGroups.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Remove selected scan groups.

--- a/MF/V3/Tasks/RemoveProjects.proto
+++ b/MF/V3/Tasks/RemoveProjects.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Remove selected projects.

--- a/MF/V3/Tasks/RestoreFactoryCalibration.proto
+++ b/MF/V3/Tasks/RestoreFactoryCalibration.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Restore factory calibration.

--- a/MF/V3/Tasks/RotateTurntable.proto
+++ b/MF/V3/Tasks/RotateTurntable.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Rotate the turntable.

--- a/MF/V3/Tasks/ScanData.proto
+++ b/MF/V3/Tasks/ScanData.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/ScanData.proto";
 import "MF/V3/Descriptors/ScanData.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Download the raw scan data for a scan in the current open project.

--- a/MF/V3/Tasks/SetCameras.proto
+++ b/MF/V3/Tasks/SetCameras.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Camera.proto";
 import "MF/V3/Descriptors/Settings/Camera.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Apply camera settings to one or both cameras.

--- a/MF/V3/Tasks/SetGroup.proto
+++ b/MF/V3/Tasks/SetGroup.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Group.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Set scan group properties.

--- a/MF/V3/Tasks/SetProject.proto
+++ b/MF/V3/Tasks/SetProject.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Project.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Apply settings to the current open project.

--- a/MF/V3/Tasks/SetProjector.proto
+++ b/MF/V3/Tasks/SetProjector.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Projector.proto";
 import "MF/V3/Descriptors/Settings/Projector.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Apply projector settings.

--- a/MF/V3/Tasks/Shutdown.proto
+++ b/MF/V3/Tasks/Shutdown.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Shutdown the scanner.

--- a/MF/V3/Tasks/SplitGroup.proto
+++ b/MF/V3/Tasks/SplitGroup.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Split a scan group (ie. move its subgroups to its parent group).

--- a/MF/V3/Tasks/StartVideo.proto
+++ b/MF/V3/Tasks/StartVideo.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Settings/Video.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Start the video stream.

--- a/MF/V3/Tasks/StopVideo.proto
+++ b/MF/V3/Tasks/StopVideo.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Stop the video stream.

--- a/MF/V3/Tasks/SystemInfo.proto
+++ b/MF/V3/Tasks/SystemInfo.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Software.proto";
 import "MF/V3/Descriptors/System.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Get system information including the serial number, disk space and installed and available software versions.

--- a/MF/V3/Tasks/TransformGroup.proto
+++ b/MF/V3/Tasks/TransformGroup.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Group.proto";
 import "MF/V3/Descriptors/Project.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Apply a rigid transformation to a group.

--- a/MF/V3/Tasks/TurntableCalibration.proto
+++ b/MF/V3/Tasks/TurntableCalibration.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "MF/V3/Task.proto";
 import "MF/V3/Descriptors/Calibration.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Get the turntable calibration descriptor.

--- a/MF/V3/Tasks/UpdateSettings.proto
+++ b/MF/V3/Tasks/UpdateSettings.proto
@@ -4,7 +4,7 @@ import "MF/V3/Task.proto";
 import "MF/V3/Settings/Scanner.proto";
 import "MF/V3/Descriptors/Settings/Scanner.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Update scanner settings.

--- a/MF/V3/Tasks/UploadProject.proto
+++ b/MF/V3/Tasks/UploadProject.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "MF/V3/Task.proto";
 
-package MF.V3;
+package MF.V3.Tasks;
 
 /**
  * Upload a project to the scanner.  The project must be archived in a ZIP file.


### PR DESCRIPTION
Tasks are missing a proper namespace.
Namespaces for Descriptors and Settings are proper, so this PR updates Tasks to match that convention. 
Currently all the tasks live under `MF.V3`, instead of `MF.V3.Tasks`. 
